### PR TITLE
Adding two new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,6 @@ alt="Demo" width="240" height="180" border="10" /></a>
 1. Youtube-dl
 2. BeautifulSoup
 
-Run `pip install -r requirements.txt` 
+Run `sh install.sh` 
  
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ "$(uname)" == "Darwin" ]; then
+    # Mac OS found. Installing deps
+    sudo easy_install pip
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    # Linux platform found. Installing deps.
+    sudo apt-get install python-pip python-dev build-essential libav-tools;
+    sudo pip install --upgrade pip;
+    sudo pip install --upgrade virtualenv;
+else
+    echo "Installer supports debian and mac only."
+fi
+pip install -r requirements.txt

--- a/music_downloader.py
+++ b/music_downloader.py
@@ -6,11 +6,18 @@ from bs4 import BeautifulSoup
 import urllib2
 from urllib import quote_plus as qp
 
-search = 'love story taylor' #I love you Taylor swift!
-search = raw_input('Enter songname/ lyrics/ artist.. or whatever ')
+# High Quality Songs, yeah baby!
+DEFAULT_AUDIO_QUALITY = '320K'
+
+search = ''
+# We do not want to except empty inputs :)
+while search == '':
+  search = raw_input('Enter songname/ lyrics/ artist.. or whatever ')
 search = qp(search)
 
 print('Making a Query Request! ')
+
+# Magic happens here.
 response = urllib2.urlopen('https://www.youtube.com/results?search_query='+search)
 html = response.read()
 soup = BeautifulSoup(html, 'html.parser')
@@ -18,12 +25,16 @@ for link in soup.find_all('a'):
     if '/watch?v=' in link.get('href'):
     	print(link.get('href'))
     	# May change when Youtube Website may get updated in the future.
-    	proper_linl = link.get('href')
+    	video_link = link.get('href')
     	break
- 
-proper_linl =  'http://www.youtube.com/'+proper_linl
-command = 'youtube-dl --extract-audio --audio-format mp3 '+proper_linl
-print ('Processed Querying , Starting Phase 2')
+
+# Links are relative on page, making them absolute.
+video_link =  'http://www.youtube.com/'+proper_linl
+command = ('youtube-dl --extract-audio --audio-format mp3 --audio-quality ' +
+           DEFAULT_AUDIO_QUALITY + ' ' +proper_linl)
+
+# Youtube-dl is a proof that god exists.
+print ('Downloading...')
 os.system(command)
 
 

--- a/music_downloader.py
+++ b/music_downloader.py
@@ -29,9 +29,9 @@ for link in soup.find_all('a'):
     	break
 
 # Links are relative on page, making them absolute.
-video_link =  'http://www.youtube.com/'+proper_linl
+video_link =  'http://www.youtube.com/'+video_link
 command = ('youtube-dl --extract-audio --audio-format mp3 --audio-quality ' +
-           DEFAULT_AUDIO_QUALITY + ' ' +proper_linl)
+           DEFAULT_AUDIO_QUALITY + ' ' +video_link)
 
 # Youtube-dl is a proof that god exists.
 print ('Downloading...')


### PR DESCRIPTION
Adding a installer script:
- Everyone does not have pip install (maybe :P)
- on ubuntu youtube-dl requires a package :libav-tools (check https://github.com/rg3/youtube-dl/issues/3160)
- making sure the installer works fine with debian and mac os.

Music downloader (Fixes):
- We do not want to make blank queries to youtube.
- We want the music in high quality by default. youtube-dl defaults at 128K.

Cheers!