### PR TITLE
Added Windows installation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ venv/
 *.mp3
 *.m4a
 *.part
+*.webm

--- a/install.bat
+++ b/install.bat
@@ -12,11 +12,16 @@ copy ".\music_downloader.py" "%UserProfile%\music_downloader\music_downloader.py
 
 echo. ";%PATH%;" | findstr /C:";%UserProfile%\music_downloader;" 1>nul
 if errorlevel 1 (
-	@setx PATH "%PATH%;%UserProfile%\music_downloader" /m
+    set svar="%PATH%;%UserProfile%\music_downloader;;"
+    goto strlen
+    :pathok
+    @setx PATH "%PATH%;%UserProfile%\music_downloader" /m
+    goto end
 ) ELSE (
 	echo Already exists in PATH
 )
 
+:end
 set /p tempvar="SUCCESS. Press Enter to continue"
 exit /B
 
@@ -33,4 +38,25 @@ rem http://stackoverflow.com/a/11995662/2295672
     ) else (
         echo Failure: Try running as administrator
     	pause >nul
+        exit /B
+    )
+
+rem http://stackoverflow.com/a/5841587/2295672
+
+:strlen
+    rem setlocal EnableDelayedExpansion for changing var and using it in loop
+    setlocal EnableDelayedExpansion
+    set "s=!%svar%!#"
+    set "len=0"
+    for %%P in (4096 2048 1024 512 256 128 64 32 16 8 4 2 1) do (
+        if "!s:~%%P,1!" NEQ "" ( 
+            set /a "len+=%%P"
+            set "s=!s:~%%P!"
+        )
+    )
+    if %len% GEQ 1024 (
+        set /p tempvar="PATH is more than 1024 characters. This can't be handled by the script. You will have to add that manually."
+        exit /b
+    ) else (
+        goto pathok
     )

--- a/install.bat
+++ b/install.bat
@@ -9,7 +9,14 @@ goto check_Permissions
 :back
 mkdir "%UserProfile%\music_downloader"
 copy ".\music_downloader.py" "%UserProfile%\music_downloader\music_downloader.py"
-@setx PATH "%PATH%;%UserProfile%\music_downloader" /m
+
+echo. ";%PATH%;" | findstr /C:";%UserProfile%\music_downloader;" 1>nul
+if errorlevel 1 (
+	@setx PATH "%PATH%;%UserProfile%\music_downloader" /m
+) ELSE (
+	echo Already exists in PATH
+)
+
 set /p tempvar="SUCCESS. Press Enter to continue"
 exit /B
 

--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,29 @@
+@echo off
+cd %~dp0
+rem Script goes to System32 if you start it as admin
+
+echo This will copy Music-Downloader to %UserProfile%\music_downloader and set it in PATH.
+
+goto check_Permissions
+
+:back
+mkdir "%UserProfile%\music_downloader"
+copy ".\music_downloader.py" "%UserProfile%\music_downloader\music_downloader.py"
+@setx PATH "%PATH%;%UserProfile%\music_downloader" /m
+set /p tempvar="SUCCESS. Press Enter to continue"
+exit /B
+
+
+rem http://stackoverflow.com/a/11995662/2295672
+
+:check_Permissions
+    echo Administrative permissions required. Detecting permissions...
+
+    net session >nul 2>&1
+    if %errorLevel% == 0 (
+        rem echo Success: Administrative permissions confirmed.
+        goto back
+    ) else (
+        echo Failure: Try running as administrator
+    	pause >nul
+    )

--- a/install.bat
+++ b/install.bat
@@ -10,6 +10,7 @@ goto check_Permissions
 mkdir "%UserProfile%\music_downloader"
 copy ".\music_downloader.py" "%UserProfile%\music_downloader\music_downloader.py"
 
+rem check if already exists in PATH
 echo. ";%PATH%;" | findstr /C:";%UserProfile%\music_downloader;" 1>nul
 if errorlevel 1 (
     set svar="%PATH%;%UserProfile%\music_downloader;;"
@@ -17,6 +18,7 @@ if errorlevel 1 (
     :pathok
     @setx PATH "%PATH%;%UserProfile%\music_downloader" /m
     goto end
+    rem needed as if-else logic is lost after goto
 ) ELSE (
 	echo Already exists in PATH
 )


### PR DESCRIPTION
Added install.bat which will copy music_downloader.py to `C:/Users/UserName/music_downloader` folder and add the directory to PATH. I have tested it and it should be good to merge but there is one issue. 
setx command supports only upto 1024 characters so if a user's PATH is long in length, the script wont be able to add to PATH. But this should happen in very few cases. I personally have a lot of compilers/stuff added to PATH but still its length is around 900 characters.
You decide.