### PR TITLE
added .gitattributes to vendor installer files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.bat linguist-vendored=true
+*.sh linguist-vendored=true


### PR DESCRIPTION
Installer files install.sh and install.bat take up a large quota in linguist stats and may even affect the language detected of your repo.
Example https://github.com/aviaryan/Instant-Music-Downloader/tree/4855e1c7c2f4784343e740101ab3564c46c5aff9 shows 46% batch file (the majority) and so the language for the project is detected as Batch, something you don't want.
