### PR TITLE
Add non unicode console support

### DIFF
--- a/instantmusic-0.1/bin/instantmusic
+++ b/instantmusic-0.1/bin/instantmusic
@@ -49,7 +49,7 @@ def grab_albumart(search=''):
 
 def list_movies(movies):
     for idx, (title, _) in enumerate(movies):
-        yield '[{}] {}'.format(idx, title.decode('utf-8').encode(sys.stdout.encoding))
+        yield '[{}] {}'.format(idx, title.decode('utf-8').encode(sys.stdout.encoding,'replace'))
 
 
 def search_videos(query):


### PR DESCRIPTION
The windows command prompt is ASCII only. This makes it so instantmusic doesn't crash when there is a non ASCII character in a song title. This does not affect consoles with unicode support.